### PR TITLE
Update api.js to prevent Mixed content

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const api = axios.create({
-  baseURL: 'http://newsapi.org/v2/everything?q=apple&from=2020-09-11&to=2020-09-11&sortBy=popularity&apiKey=05464b99b3b247f0aff76bc370e05ec0'
+  baseURL: 'https://newsapi.org/v2/everything?q=apple&from=2020-09-11&to=2020-09-11&sortBy=popularity&apiKey=05464b99b3b247f0aff76bc370e05ec0'
 })
 
 export default api;


### PR DESCRIPTION
Prevent mixed content when serve application with `https` and consumes an api with `http` (see the image below)

![image](https://user-images.githubusercontent.com/11355873/93018445-34f3f180-f5a6-11ea-9f5d-c0d5224ab369.png)

Read more of this in MDN: https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content

You can also serve your application with `http` once the referenced API doesn't support free `https` requests 